### PR TITLE
Fix convert bug and allow officeID filtering

### DIFF
--- a/src/elexclarity/convert.py
+++ b/src/elexclarity/convert.py
@@ -6,6 +6,10 @@ def convert(data, statepostal, outputType="results", style="default", countyMapp
     """
     The entry point for formatting Clarity results data.
     """
+
+    if kwargs.get("officeID") and type(kwargs.get("officeID")) == str:
+        kwargs["officeID"] = kwargs["officeID"].split(",")
+
     if style == "raw" or outputType == "summary":
         return data
 
@@ -20,9 +24,13 @@ def convert(data, statepostal, outputType="results", style="default", countyMapp
             statepostal,
             county_lookup=countyMapping
         )
-        results = {}
-        for sub_result in data:
-            results.update(converter.convert(sub_result, **kwargs))
-        return results
+
+        if type(data) == list:
+            results = {}
+            for sub_result in data:
+                results.update(converter.convert(sub_result, **kwargs))
+            return results
+        else:
+            return converter.convert(data, **kwargs)
 
     raise Exception(f"The {outputType} Clarity formatter is not implemented yet")

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -116,11 +116,12 @@ class ClarityDetailXMLConverter(ClarityConverter):
 
         choices = get_list(contest["Choice"])
         contest_name = contest["text"]
+        office = self.get_race_office(contest_name)
         id_parts = [
             election_date,
             self.state_postal,
             election_type,
-            self.get_race_office(contest_name)
+            office
         ]
         if level == "precinct":
             id_parts.append(county_id)
@@ -130,7 +131,8 @@ class ClarityDetailXMLConverter(ClarityConverter):
             "id": race_id,
             "source": "clarity",
             "precinctsReportingPct": precincts_reporting_pct,
-            "counts": self.format_top_level_counts(choices)
+            "counts": self.format_top_level_counts(choices),
+            "office": office
         }
         if timestamp:
             result["lastUpdated"] = timestamp
@@ -154,6 +156,9 @@ class ClarityDetailXMLConverter(ClarityConverter):
         election_type = self.get_race_type(dictified_data["ElectionName"])
         timestamp = self.format_last_updated(dictified_data["Timestamp"])
 
+
+        officeID = kwargs.get("officeID", ())
+
         for contest in get_list(dictified_data.get("Contest")):
             race_result = self.format_race(
                 contest,
@@ -164,5 +169,9 @@ class ClarityDetailXMLConverter(ClarityConverter):
                 timestamp=timestamp,
                 **kwargs
             )
-            result[race_result["id"]] = race_result
+
+            office = race_result.get('office')
+            if not officeID or office in officeID:
+                result[race_result["id"]] = race_result
+
         return result

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -23,3 +23,15 @@ def test_county_level_results(ga_counties, ga_county_mapping_fips):
 
     assert len(results) == 2
     assert "2020-11-03_GA_G_P" in results
+
+def test_single_result_object(ga_counties, ga_county_mapping_fips):
+    results = convert(ga_counties, statepostal="GA", level="county", countyMapping=ga_county_mapping_fips)
+
+    assert len(results) == 2
+    assert "2020-11-03_GA_G_P" in results
+
+def test_filter_officeid(ga_counties, ga_county_mapping_fips):
+    results = convert(ga_counties, statepostal="GA", level="county", countyMapping=ga_county_mapping_fips, officeID="P")
+
+    assert len(results) == 1
+    assert "2020-11-03_GA_G_P" in results


### PR DESCRIPTION
## Description

This makes two little improvements onto #8:
- It fixes a bug that occurred when calling `.convert` with a single result object (rather than a list)
- It allows the use of an `officeID` param to filter results during the formatting step