### PR TITLE
feat: Include county name in settings exports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open(os.path.join(THIS_FILE_DIR, 'README.rst'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 
 # The full version, including alpha/beta/rc tags
-RELEASE = '0.0.1-beta.0'
+RELEASE = '0.0.1-beta.1'
 # The short X.Y version
 VERSION = '.'.join(RELEASE.split('.')[:2])
 

--- a/src/elexclarity/formatters/settings.py
+++ b/src/elexclarity/formatters/settings.py
@@ -27,6 +27,7 @@ class ClaritySettingsConverter(ClarityConverter):
                     ])
                     race_id_settings_mapping[race_id] = {
                         "id": race_id,
+                        "name": name,
                         "version": version,
                         "lastUpdated": last_updated,
                         "clarityId": clarity_id

--- a/tests/formatters/test_settings.py
+++ b/tests/formatters/test_settings.py
@@ -8,12 +8,14 @@ def test_format_county_settings(recorder, api_client, ga_county_mapping_fips):
         assert len(result) == 159
         assert result["2020-11-03_GA_G_S_13001"] == {
             'clarityId': '105371',
+            'name': 'Appling',
             'id': '2020-11-03_GA_G_S_13001',
             'lastUpdated': '2020-11-16T20:48:35Z',
             'version': '271560'
         }
         assert result["2020-11-03_GA_G_S_13277"] == {
             'clarityId': '105507',
+            'name': 'Tift',
             'id': '2020-11-03_GA_G_S_13277',
             'lastUpdated': '2020-11-06T22:50:20Z',
             'version': '270028'


### PR DESCRIPTION
## Description

Since the `get_county_results` method requires `county_name`, `county_id`, and `county_version`, I think it makes sense to include all three of those in a settings-style output.

I suppose we could theoretically do a reverse lookup from the FIPS code to name, but there's all sorts of formatting edge cases (e.g. `DeKalb`, `Jeff_Davis`, etc). It also seems potentially more generalizable to other states if we pass around `name`, rather than relying on a static mapping. (But if you feel strongly about another approach, I'm happy to adjust!)

## Jira Ticket
[ELECT-1599]

## Test Steps
Run a settings export, and make sure each county has a `name`, `clarityId`, and `version` attribute.
```
elexclarity 105369 GA --outputType=settings --officeID=S,S2
```

[ELECT-1599]: https://arcpublishing.atlassian.net/browse/ELECT-1599