### PR TITLE
Feature: adds voteCompletionMode parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,11 @@
 ## [0.0.1] - (Not yet published)
 
 - Initial release!
+
+## [0.0.1-beta.2]
+
+- Adds a `voteCompletionMode` parameter to switch between using the `percentReporting` field vs vote counts by type to determine whether a precinct is fully reporting
+
+## [0.0.1-beta.1]
+
+- Initial beta release with county-level settings formatting and precinct, county, and state-level results formatting

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,11 @@ Other parameters
      - object
      - N
      - -- 
+   * - voteCompletionMode
+     - the method that should be used to determine whether a precinct is fully reporting 
+     - string
+     - N
+     - percentReporting
    * - filename
      - the path to read results from (if you don't want to ping a Clarity site)
      - string
@@ -136,6 +141,7 @@ Retrieving + formatting results:
 
 * ``elexclarity 105369 GA --level=precinct --countyMapping='{"Worth": "13321"}'``
 * ``elexclarity 105369 GA --level=precinct``
+* ``elexclarity 105369 GA --level=precinct --voteCompletionMode=voteTypes``
 * ``elexclarity 105369 GA --level=county``
 * ``elexclarity 106210 WV --level=county --countyMapping='<mapping json>'``
 * ``elexclarity 105369 WV --level=state``

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open(os.path.join(THIS_FILE_DIR, 'README.rst'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 
 # The full version, including alpha/beta/rc tags
-RELEASE = '0.0.1-beta.1'
+RELEASE = '0.0.1-beta.2'
 # The short X.Y version
 VERSION = '.'.join(RELEASE.split('.')[:2])
 

--- a/src/elexclarity/cli.py
+++ b/src/elexclarity/cli.py
@@ -33,6 +33,10 @@ STRING_LIST = StringListParamType()
     'settings',
     'results'
 ]))
+@click.option('--voteCompletionMode', 'voteCompletionMode', default='percentReporting', type=click.Choice([
+    'percentReporting',
+    'voteTypes'
+]))
 @click.option('--style', default='default', type=click.Choice([
     'default',
     'raw'

--- a/src/elexclarity/convert.py
+++ b/src/elexclarity/convert.py
@@ -2,13 +2,25 @@ from elexclarity.formatters.results import ClarityDetailXMLConverter
 from elexclarity.formatters.settings import ClaritySettingsConverter
 
 
-def convert(data, statepostal, outputType="results", style="default", countyMapping=None, **kwargs):
+def convert(
+    data,
+    statepostal,
+    outputType="results",
+    style="default",
+    countyMapping=None,
+    officeID=None,
+    voteCompletionMode=None,
+    **kwargs
+):
     """
     The entry point for formatting Clarity results data.
     """
 
-    if kwargs.get("officeID") and type(kwargs.get("officeID")) == str:
-        kwargs["officeID"] = kwargs["officeID"].split(",")
+    office_id = officeID
+    vote_completion_mode = voteCompletionMode
+
+    if office_id and isinstance(office_id, str):
+        office_id = office_id.split(",")
 
     if style == "raw" or outputType == "summary":
         return data
@@ -16,6 +28,7 @@ def convert(data, statepostal, outputType="results", style="default", countyMapp
     if outputType == "settings":
         return ClaritySettingsConverter(statepostal, county_lookup=countyMapping).convert(
             data,
+            office_id=office_id,
             **kwargs
         )
 
@@ -25,12 +38,22 @@ def convert(data, statepostal, outputType="results", style="default", countyMapp
             county_lookup=countyMapping
         )
 
-        if type(data) == list:
+        if isinstance(data, list):
             results = {}
             for sub_result in data:
-                results.update(converter.convert(sub_result, **kwargs))
+                results.update(converter.convert(
+                    sub_result,
+                    vote_completion_mode=vote_completion_mode,
+                    office_id=office_id,
+                    **kwargs
+                ))
             return results
         else:
-            return converter.convert(data, **kwargs)
+            return converter.convert(
+                data,
+                vote_completion_mode=vote_completion_mode,
+                office_id=office_id,
+                **kwargs
+            )
 
     raise Exception(f"The {outputType} Clarity formatter is not implemented yet")

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from slugify import slugify
 import xmltodict
 
 from elexclarity.formatters.base import ClarityConverter
@@ -75,6 +74,10 @@ class ClarityDetailXMLConverter(ClarityConverter):
         return subunits
 
     def get_vote_totals_by_vote_types(self, choices, level):
+        """
+        Creates a mapping from subunit IDs to the total number of votes in
+        for that vote type across all choices.
+        """
         subunit_vote_types = {}
         clarity_level = level.capitalize()
 
@@ -213,8 +216,9 @@ class ClarityDetailXMLConverter(ClarityConverter):
             result["lastUpdated"] = timestamp
         if level in ["precinct", "county"]:
             choices = self._get_valid_contest_choices(contest)
-            # if we're using vote completion mode "voteTypes", we look at the number of votes for each vote type
-            # for each contest so we have to construct the reporting statuses mapping here
+            # if we're using vote completion mode "voteTypes", we look at the number of votes
+            # for each vote type for each contest so we have to construct the reporting
+            # statuses mapping here
             if subunit_fully_reporting_statuses is None and level == "precinct" and vote_completion_mode == "voteTypes":
                 subunit_fully_reporting_statuses = self._get_precinct_fully_reporting_statuses_via_vote_types(contest)
             result["subunits"] = self.format_subunits(choices, level, subunit_fully_reporting_statuses)

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -112,7 +112,8 @@ class ClarityDetailXMLConverter(ClarityConverter):
             for subunit_id, subunit_result in subunit_results.items():
                 is_subunit_fully_reporting = subunit_fully_reporting_statuses.get(subunit_id, False)
                 subunit_result["precinctsReportingPct"] = 100 if is_subunit_fully_reporting else 0
-                subunit_result["expectedVotes"] = sum(subunit_results[subunit_id]["counts"].values()) if is_subunit_fully_reporting else 0
+                if is_subunit_fully_reporting:
+                    subunit_result["expectedVotes"] = sum(subunit_results[subunit_id]["counts"].values())
         return subunit_results
 
     def format_top_level_counts(self, choices):
@@ -150,10 +151,8 @@ class ClarityDetailXMLConverter(ClarityConverter):
         """
         Constructs a mapping from precinct IDs to boolean flags representing
         whether or not the given precinct is fully reporting. This method does so by looking
-        at the VoterTurnout from the ElectionResults tag in the precinct details xml
-        and checking if ``percentReporting`` is 4. This means (we think) that all 4 vote
-        types (early/absentee/day of in person/provisional) have been reported for the
-        given precinct.
+        at the various vote types for each precinct and checking that some votes are
+        in for each of those types (except provisional votes).
         """
         choices = self._get_valid_contest_choices(contest)
         subunit_fully_reporting_statuses = {}

--- a/src/elexclarity/formatters/settings.py
+++ b/src/elexclarity/formatters/settings.py
@@ -6,7 +6,7 @@ class ClaritySettingsConverter(ClarityConverter):
     A class to convert Clarity JSON settings.
     """
 
-    def convert(self, data, level="county", officeID=(), **kwargs):
+    def convert(self, data, level="county", office_id=(), **kwargs):
         if level == "county":
             raw_counties = data.get("settings", {}).get("electiondetails", {}).get("participatingcounties")
             raw_date = data.get("settings", {}).get("electiondetails", {}).get("electiondate")
@@ -17,12 +17,12 @@ class ClaritySettingsConverter(ClarityConverter):
             for raw_county in raw_counties:
                 name, clarity_id, version, raw_last_updated = raw_county.split("|")[0:4]
                 last_updated = self.format_last_updated(raw_last_updated)
-                for office_id in officeID:
+                for office in office_id:
                     race_id = "_".join([
                         election_date,
                         self.state_postal,
                         self.get_race_type(raw_type),
-                        office_id,
+                        office,
                         self.get_county_id(name)
                     ])
                     race_id_settings_mapping[race_id] = {

--- a/tests/fixtures/results/ga_atkinson_precincts_11-3.xml
+++ b/tests/fixtures/results/ga_atkinson_precincts_11-3.xml
@@ -31,7 +31,7 @@
             <VoteType name="Election Day Votes" votes="716">
                 <Precinct name="Pearson County" votes="235" />
                 <Precinct name="Axson" votes="194" />
-                <Precinct name="Willacoochee" votes="224" />
+                <Precinct name="Willacoochee" votes="0" />
                 <Precinct name="Pearson City" votes="63" />
             </VoteType>
             <VoteType name="Advanced Voting Votes" votes="1419">
@@ -57,7 +57,7 @@
             <VoteType name="Election Day Votes" votes="250">
                 <Precinct name="Pearson County" votes="32" />
                 <Precinct name="Axson" votes="25" />
-                <Precinct name="Willacoochee" votes="117" />
+                <Precinct name="Willacoochee" votes="0" />
                 <Precinct name="Pearson City" votes="76" />
             </VoteType>
             <VoteType name="Advanced Voting Votes" votes="445">
@@ -83,7 +83,7 @@
             <VoteType name="Election Day Votes" votes="14">
                 <Precinct name="Pearson County" votes="5" />
                 <Precinct name="Axson" votes="1" />
-                <Precinct name="Willacoochee" votes="4" />
+                <Precinct name="Willacoochee" votes="0" />
                 <Precinct name="Pearson City" votes="4" />
             </VoteType>
             <VoteType name="Advanced Voting Votes" votes="13">

--- a/tests/formatters/test_results.py
+++ b/tests/formatters/test_results.py
@@ -2,11 +2,15 @@ from elexclarity.formatters.results import ClarityDetailXMLConverter
 
 
 def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping_fips):
-    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(atkinson_precincts, level="precinct")
+    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(
+        atkinson_precincts,
+        level="precinct"
+    )
 
     assert len(results) == 25
     assert results["2020-11-03_GA_G_P_13003"]["precinctsReportingPct"] == 100
     assert results["2020-11-03_GA_G_P_13003"]["lastUpdated"] == "2020-11-06T18:05:50Z"
+    assert len(results["2020-11-03_GA_G_P_13003"]["subunits"]) == 4
 
     # Top level counts for this county
     counts = results["2020-11-03_GA_G_P_13003"]["counts"]
@@ -14,12 +18,40 @@ def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping
     assert counts["joseph_r_biden_dem"] == 825
     assert counts["jo_jorgensen_lib"] == 30
 
-    # Subunit
-    assert len(results["2020-11-03_GA_G_P_13003"]["subunits"]) == 4
+    # Pearson City precinct
     pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["pearson_city"]
+    assert pearson["precinctsReportingPct"] == 100
+    assert pearson["expectedVotes"] == 564
     assert pearson["counts"]["donald_j_trump_i_rep"] == 229
     assert pearson["counts"]["joseph_r_biden_dem"] == 329
     assert pearson["counts"]["jo_jorgensen_lib"] == 6
+
+    # Willacoochee precinct
+    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
+    assert willacoochee["precinctsReportingPct"] == 100
+    assert willacoochee["expectedVotes"] == 522
+    assert willacoochee["counts"]["donald_j_trump_i_rep"] == 342
+    assert willacoochee["counts"]["joseph_r_biden_dem"] == 174
+    assert willacoochee["counts"]["jo_jorgensen_lib"] == 6
+
+
+def test_georgia_precinct_formatting_vote_types_completion_mode(atkinson_precincts, ga_county_mapping_fips):
+    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(
+        atkinson_precincts,
+        level="precinct",
+        office_id="P",
+        vote_completion_mode="voteTypes"
+    )
+
+    # Pearson City precinct
+    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["pearson_city"]
+    assert pearson["precinctsReportingPct"] == 100
+    assert pearson["expectedVotes"] == 564
+
+    # Willacoochee precinct
+    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
+    assert willacoochee["precinctsReportingPct"] == 0
+    assert willacoochee["expectedVotes"] == 0
 
 
 def test_georgia_precinct_formatting_race_name_mapping(gwinnett_precincts, ga_county_mapping_fips):
@@ -27,7 +59,10 @@ def test_georgia_precinct_formatting_race_name_mapping(gwinnett_precincts, ga_co
     Gwinnett has some special contest names so this test makes sure that those get mapped
     to the right office IDs
     '''
-    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(gwinnett_precincts, level="precinct")
+    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(
+        gwinnett_precincts,
+        level="precinct"
+    )
 
     # President
     assert "2020-11-03_GA_G_P_13135" in results
@@ -38,7 +73,10 @@ def test_georgia_precinct_formatting_race_name_mapping(gwinnett_precincts, ga_co
 
 
 def test_georgia_state_formatting_basic(ga_counties, ga_county_mapping_fips):
-    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(ga_counties, level="state")
+    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(
+        ga_counties,
+        level="state"
+    )
 
     assert len(results) == 2
     assert "2020-11-03_GA_G_P" in results
@@ -53,7 +91,10 @@ def test_georgia_state_formatting_basic(ga_counties, ga_county_mapping_fips):
 
 
 def test_georgia_county_formatting_basic(ga_counties, ga_county_mapping_fips):
-    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(ga_counties, level="county")
+    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(
+        ga_counties,
+        level="county"
+    )
 
     assert len(results["2020-11-03_GA_G_P"]["subunits"]) == 159
     # County-level counts
@@ -65,7 +106,10 @@ def test_georgia_county_formatting_basic(ga_counties, ga_county_mapping_fips):
 
 
 def test_georgia_county_formatting_alternate_county_mapping(ga_counties, ga_county_mapping_alternate):
-    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_alternate).convert(ga_counties, level="county")
+    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_alternate).convert(
+        ga_counties,
+        level="county"
+    )
 
     assert len(results) == 2
     catoosa_county = results["2020-11-03_GA_G_P"]["subunits"]["22"]

--- a/tests/formatters/test_results.py
+++ b/tests/formatters/test_results.py
@@ -51,7 +51,7 @@ def test_georgia_precinct_formatting_vote_types_completion_mode(atkinson_precinc
     # Willacoochee precinct
     willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
     assert willacoochee["precinctsReportingPct"] == 0
-    assert willacoochee["expectedVotes"] == 0
+    assert willacoochee.get("expectedVotes") is None
 
 
 def test_georgia_precinct_formatting_race_name_mapping(gwinnett_precincts, ga_county_mapping_fips):

--- a/tests/formatters/test_settings.py
+++ b/tests/formatters/test_settings.py
@@ -4,7 +4,7 @@ from elexclarity.formatters.settings import ClaritySettingsConverter
 def test_format_county_settings(recorder, api_client, ga_county_mapping_fips):
     with recorder.use_cassette('settings/GA_2020'):
         settings = api_client.get_settings(105369, 'GA')
-        result = ClaritySettingsConverter('GA', county_lookup=ga_county_mapping_fips).convert(settings, officeID=("S"), level="county")
+        result = ClaritySettingsConverter('GA', county_lookup=ga_county_mapping_fips).convert(settings, office_id=("S"), level="county")
         assert len(result) == 159
         assert result["2020-11-03_GA_G_S_13001"] == {
             'clarityId': '105371',

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -24,11 +24,13 @@ def test_county_level_results(ga_counties, ga_county_mapping_fips):
     assert len(results) == 2
     assert "2020-11-03_GA_G_P" in results
 
+
 def test_single_result_object(ga_counties, ga_county_mapping_fips):
     results = convert(ga_counties, statepostal="GA", level="county", countyMapping=ga_county_mapping_fips)
 
     assert len(results) == 2
     assert "2020-11-03_GA_G_P" in results
+
 
 def test_filter_officeid(ga_counties, ga_county_mapping_fips):
     results = convert(ga_counties, statepostal="GA", level="county", countyMapping=ga_county_mapping_fips, officeID="P")


### PR DESCRIPTION
## Description
We need a way to signal that a precinct has fully reported its results. This PR adds two different methods of doing so and a corresponding CLI flag for switching between those methods (`voteTypes` and `percentReporting`).

The `voteTypes` method checks that _some_ votes have been reported for each vote type (early, absentee, day of in person) other than provisional in a given precinct. This is happening per-race so there are a couple ways that it could be inaccurate.

The `percentReporting` method uses the `percentReporting` field which is populated on every precinct inside a `VoterTurnout` block in every precinct detail xml file. This field basically can't be holding a percentage value because it is set to 4 for every precinct in every single file I have looked at. There are, however, 4 vote types, so I'm guessing this field is actually telling us how many vote types are reporting.

I also corrected some pycodestyle issues and updated the `convert` method to pass snake case variable names to the formatters.

## Jira Ticket

## Test Steps
Verify that various CLI commands still work as expected. Try out the `voteTypes` vote completion mode:

- `elexclarity 105369 GA --level=precinct --officeID=P > ga_precincts.json`
- `elexclarity 105369 GA --level=precinct --voteCompletionMode=voteTypes --officeID=P > ga_precincts_vote_types.json`

The former leaves 0 precincts not fully reporting while the latter leaves 11.