### PR TITLE
fix: Count runoffs as race_type "G"

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -10,9 +10,9 @@ class ClarityConverter(object):
         self.county_lookup = county_lookup
 
     def get_race_type(self, election_name):
-        if "General" in election_name:
+        if "General" or "Runoff" in election_name:
             return "G"
-        raise Exception("Unknown election type")
+        raise Exception(f"Unknown election type: {election_name}")
 
     def get_race_office(self, contest_name):
         return STATE_OFFICE_ID_MAPS[self.state_postal].get(contest_name, slugify(contest_name, separator="_"))


### PR DESCRIPTION
## Description

The Jan. 5 Georgia Runoff has an `election_name` of "January 5, 2021 Federal Runoff."

In the longer term, we should probably find a better way of setting the election type — but for now we can add "Runoff" to the list of general-election types as a quick and easy fix.

## Jira Ticket

## Test Steps
CLI commands for the Jan. 5 runoff should work:
```
elexclarity 107556 GA --level=county --officeID=S,S2
elexclarity 107556 GA --level=county --outputType=settings --officeID=S,S2
```
(Precinct results appear to not be available yet.)