### PR TITLE
Feature: Add GA primaries office names

### DIFF
--- a/src/elexclarity/formatters/const.py
+++ b/src/elexclarity/formatters/const.py
@@ -8,6 +8,13 @@ STATE_OFFICE_ID_MAPS = {
         'US Senate (Loeffler) - Special/Senado de los EE.UU. (Loeffler) - Especial': 'S2',
         'US Senate (Perdue)': 'S',
         'US Senate (Perdue)/Senado de los EE.UU. (Perdue)': 'S',
+        # 2022 primaries
+        'US Senate - Rep': 'S',
+        'US Senate - Dem': 'S',
+        'Governor - Rep': 'G',
+        'Governor - Dem': 'G',
+        'Secretary of State - Rep': 'R',
+        'Secretary of State - Dem': 'R'
     },
     "WV": {
         'PRESIDENT': 'P',

--- a/src/elexclarity/formatters/const.py
+++ b/src/elexclarity/formatters/const.py
@@ -10,10 +10,16 @@ STATE_OFFICE_ID_MAPS = {
         'US Senate (Perdue)/Senado de los EE.UU. (Perdue)': 'S',
         # 2022 primaries
         'US Senate - Rep': 'S',
+        'REP - US Senate': 'S',
+        'DEM - US Senate': 'S',
         'US Senate - Dem': 'S',
         'Governor - Rep': 'G',
+        'REP - Governor': 'G',
+        'DEM - Governor': 'G',
         'Governor - Dem': 'G',
         'Secretary of State - Rep': 'R',
+        'REP - Secretary of State': 'R',
+        'DEM - Secretary of State': 'R',
         'Secretary of State - Dem': 'R'
     },
     "WV": {


### PR DESCRIPTION
## Description
Adds office names for Gov, Senate, and Sec of State races. 

Clarity site: [https://results.enr.clarityelections.com/GA/113667/web.285569/](https://results.enr.clarityelections.com/GA/113667/web.285569/ )

## Test Steps

`elexclarity 113667 GA --level=precinct --officeID=G`
`elexclarity 113667 GA --level=precinct --officeID=S`
`elexclarity 113667 GA --level=precinct --officeID=R`
