### PR TITLE
Lookup race types, including for GA partisan primaries

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -1,7 +1,7 @@
 from slugify import slugify
 from dateutil import parser, tz
 
-from elexclarity.formatters.const import STATE_OFFICE_ID_MAPS
+from elexclarity.formatters.const import STATE_OFFICE_ID_MAPS, STATE_RACE_TYPE_MAPS
 
 
 class ClarityConverter(object):
@@ -9,7 +9,12 @@ class ClarityConverter(object):
         self.state_postal = statepostal
         self.county_lookup = county_lookup
 
-    def get_race_type(self, election_name):
+    def get_race_type(self, election_name, contest):
+        contest_name = contest['text']
+        lookup = STATE_RACE_TYPE_MAPS.get(self.state_postal, {})
+        for key, value in lookup.items():
+            if key in election_name or key in contest_name:
+                return value
         if "General" or "Runoff" in election_name:
             return "G"
         raise Exception(f"Unknown election type: {election_name}")

--- a/src/elexclarity/formatters/const.py
+++ b/src/elexclarity/formatters/const.py
@@ -16,3 +16,11 @@ STATE_OFFICE_ID_MAPS = {
     "CA": {
     }
 }
+
+STATE_RACE_TYPE_MAPS = {
+    "GA": {
+        ' - Rep': 'R',
+        ' - Dem': 'D',
+        'Primary': 'P'
+    }
+}

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -236,7 +236,6 @@ class ClarityDetailXMLConverter(ClarityConverter):
         else:
             county_id = None
         election_date = self.format_date(dictified_data["ElectionDate"])
-        election_type = self.get_race_type(dictified_data["ElectionName"])
         timestamp = self.format_last_updated(dictified_data["Timestamp"])
 
         if level == "precinct" and vote_completion_mode == "percentReporting":
@@ -247,6 +246,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
             subunit_fully_reporting_statuses = None
 
         for contest in get_list(dictified_data.get("Contest")):
+            election_type = self.get_race_type(dictified_data["ElectionName"], contest)
             race_result = self.format_race(
                 contest,
                 election_date,


### PR DESCRIPTION
## Description

Looks up race types in state specific mappings using the election and contest names, includes primary and partisan primary codes for GA.

## Test Steps
```sh
elexclarity 113667 GA --level=precinct
```
