### PR TITLE
Get current version for each county when requesting precinct files

### DIFF
--- a/src/elexclarity/client.py
+++ b/src/elexclarity/client.py
@@ -117,8 +117,9 @@ class ElectionsClient(object):
             election_settings = self.get_settings(electionid, statepostal, countyname)
             raw_counties = election_settings.get("settings", {}).get("electiondetails", {}).get("participatingcounties")
             for raw_county in raw_counties:
-                name, clarity_id, version, _ = raw_county.split("|")[0:4]
-                results.append(self.get_county_results(statepostal, name, clarity_id, version, **kwargs))
+                name, clarity_id, _, _ = raw_county.split("|")[0:4]
+                current_ver = self.get_current_version(clarity_id, statepostal, name)
+                results.append(self.get_county_results(statepostal, name, clarity_id, current_ver, **kwargs))
             return results
         elif (level == "state" or level == "county") and not countyname:
             current_ver = self.get_current_version(electionid, statepostal, countyname)


### PR DESCRIPTION
## Description

Each county and the election as a whole have both an ID and a version number. When fetching precinct results, the client:
1. Takes an ID and then requests the version ID from a URL that looks like https://results.enr.clarityelections.com//GA/113667/current_ver.txt
2. Then it client fetches the IDs and version numbers them for counties from  https://results.enr.clarityelections.com//GA/113667/291065/json/en/electionsettings.json
3. Before using the ID and the version number to construct a URL and download details for each county from https://results.enr.clarityelections.com//GA/Bacon/113671/290967/reports/detailxml.zip

However, it appears the versions for counties can get out of sync with the versions published in electionsettings.json for a given statewide-version. Perhaps the county pages can be published independently and that doesn't update the statewide file. Regardless, the result is we were getting 404s for the above county details file and a handful of others.

@emilyliu7321 noticed however that on the website, she was able to download the correct file from https://results.enr.clarityelections.com//GA/Bacon/113671/290716/reports/detailxml.zip

That's because the county details page requests the version ID from https://results.enr.clarityelections.com/GA/Bacon/113671/current_ver.txt

Which at the time of this writing correctly gives the version 290716 in the above working URL, while the statewide settings file gives the non-working ID.

So, this patch fetches the version from that file for each county, avoiding the 404s errors we were receiving.

## Test Steps
```sh
elexclarity 113667 GA --level=precinct --countyMapping="$(cat tests/fixtures/mappings/GA_county_fips.json)" > out.json
```