### PR TITLE
Add `county_id` to precinct IDs, use dash to slugify precinct names

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -21,8 +21,8 @@ class ClarityConverter(object):
     def get_choice_id(cls, name):
         return slugify(name, separator="_")
 
-    def get_precinct_id(self, name):
-        return slugify(name, separator="_")
+    def get_precinct_id(self, name, county_id=None):
+        return "_".join(filter(None,[county_id, slugify(name, separator='-')]))
 
     def get_county_id(self, name):
         """

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -11,7 +11,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
     """
     NUM_VOTE_TYPES = 4
 
-    def aggregate_choice_vote_types(self, choice, level):
+    def aggregate_choice_vote_types(self, choice, level, *, county_id=None):
         """
         Takes a Clarity `Choice` object and aggregates all the different
         kinds of votes into one total per subunit.
@@ -65,7 +65,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
             vote_type_subunits = vote_type.get(clarity_level, [])
             for vote_type_subunit in get_list(vote_type_subunits):
                 if level == "precinct":
-                    subunit_id = self.get_precinct_id(vote_type_subunit["name"])
+                    subunit_id = self.get_precinct_id(vote_type_subunit["name"], county_id=county_id)
                 else:
                     subunit_id = self.get_county_id(vote_type_subunit["name"])
 
@@ -73,7 +73,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
 
         return subunits
 
-    def get_vote_totals_by_vote_types(self, choices, level):
+    def get_vote_totals_by_vote_types(self, choices, level, *, county_id=None):
         """
         Creates a mapping from subunit IDs to the total number of votes in
         for that vote type across all choices.
@@ -85,7 +85,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
             for vote_type in get_list(choice.get("VoteType", [])):
                 vote_type_subunits = vote_type.get(clarity_level, [])
                 for vote_type_subunit in get_list(vote_type_subunits):
-                    subunit_id = self.get_precinct_id(vote_type_subunit["name"])
+                    subunit_id = self.get_precinct_id(vote_type_subunit["name"], county_id=county_id)
                     subunit_vote_types.setdefault(subunit_id, defaultdict(lambda: 0))
                     subunit_vote_types[subunit_id][vote_type["name"]] += int(vote_type_subunit["votes"])
 
@@ -94,7 +94,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
     def _get_valid_contest_choices(self, contest):
         return list(filter(lambda choice: choice.get("text"), get_list(contest["Choice"])))
 
-    def format_subunits(self, choices, level, subunit_fully_reporting_statuses=None):
+    def format_subunits(self, choices, level, subunit_fully_reporting_statuses=None, *, county_id=None):
         """
         Takes a list of `Choice` objects from Clarity and aggregates/transforms
         them into a the format our data importer expects.
@@ -102,7 +102,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
         subunit_results = {}
 
         for choice in choices:
-            choice_votes_by_subunit = self.aggregate_choice_vote_types(choice, level)
+            choice_votes_by_subunit = self.aggregate_choice_vote_types(choice, level, county_id=county_id)
             for subunit_id, subunit_choice_votes in choice_votes_by_subunit.items():
                 subunit_results.setdefault(subunit_id, {"id": subunit_id, "counts": defaultdict(lambda: 0)})
                 choice_id = self.get_choice_id(choice.get("text"))
@@ -129,7 +129,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
 
         return counts
 
-    def _get_precinct_fully_reporting_statuses_via_percent_reporting(self, election):
+    def _get_precinct_fully_reporting_statuses_via_percent_reporting(self, election, county_id=None):
         """
         Constructs a mapping from precinct IDs to boolean flags representing
         whether or not the given precinct is fully reporting. This method does so by looking
@@ -141,13 +141,13 @@ class ClarityDetailXMLConverter(ClarityConverter):
         subunit_fully_reporting_statuses = {}
         precincts = get_list(election["VoterTurnout"]["Precincts"]["Precinct"])
         for precinct in precincts:
-            subunit_id = self.get_precinct_id(precinct["name"])
+            subunit_id = self.get_precinct_id(precinct["name"], county_id=county_id)
             is_precinct_fully_reporting = (precinct.get("percentReporting") == str(self.NUM_VOTE_TYPES))
             subunit_fully_reporting_statuses[subunit_id] = is_precinct_fully_reporting
 
         return subunit_fully_reporting_statuses
 
-    def _get_precinct_fully_reporting_statuses_via_vote_types(self, contest):
+    def _get_precinct_fully_reporting_statuses_via_vote_types(self, contest, *, county_id=None):
         """
         Constructs a mapping from precinct IDs to boolean flags representing
         whether or not the given precinct is fully reporting. This method does so by looking
@@ -157,7 +157,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
         choices = self._get_valid_contest_choices(contest)
         subunit_fully_reporting_statuses = {}
 
-        vote_types_by_subunit = self.get_vote_totals_by_vote_types(choices, "precinct")
+        vote_types_by_subunit = self.get_vote_totals_by_vote_types(choices, "precinct", county_id=county_id)
         for subunit_id, vote_type_totals in vote_types_by_subunit.items():
             is_precinct_fully_reporting = True
             for vote_type, vote_total in vote_type_totals.items():
@@ -219,8 +219,8 @@ class ClarityDetailXMLConverter(ClarityConverter):
             # for each vote type for each contest so we have to construct the reporting
             # statuses mapping here
             if subunit_fully_reporting_statuses is None and level == "precinct" and vote_completion_mode == "voteTypes":
-                subunit_fully_reporting_statuses = self._get_precinct_fully_reporting_statuses_via_vote_types(contest)
-            result["subunits"] = self.format_subunits(choices, level, subunit_fully_reporting_statuses)
+                subunit_fully_reporting_statuses = self._get_precinct_fully_reporting_statuses_via_vote_types(contest, county_id=county_id)
+            result["subunits"] = self.format_subunits(choices, level, subunit_fully_reporting_statuses, county_id=county_id)
 
         return result
 
@@ -242,7 +242,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
         if level == "precinct" and vote_completion_mode == "percentReporting":
             # the default method of determining vote completion is to use the VoterTurnout
             # fields at the ElectionResult level in the precinct detail XML files
-            subunit_fully_reporting_statuses = self._get_precinct_fully_reporting_statuses_via_percent_reporting(dictified_data)
+            subunit_fully_reporting_statuses = self._get_precinct_fully_reporting_statuses_via_percent_reporting(dictified_data, county_id=county_id)
         else:
             subunit_fully_reporting_statuses = None
 

--- a/tests/formatters/test_results.py
+++ b/tests/formatters/test_results.py
@@ -19,7 +19,7 @@ def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping
     assert counts["jo_jorgensen_lib"] == 30
 
     # Pearson City precinct
-    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["pearson_city"]
+    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_pearson-city"]
     assert pearson["precinctsReportingPct"] == 100
     assert pearson["expectedVotes"] == 564
     assert pearson["counts"]["donald_j_trump_i_rep"] == 229
@@ -27,7 +27,7 @@ def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping
     assert pearson["counts"]["jo_jorgensen_lib"] == 6
 
     # Willacoochee precinct
-    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
+    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_willacoochee"]
     assert willacoochee["precinctsReportingPct"] == 100
     assert willacoochee["expectedVotes"] == 522
     assert willacoochee["counts"]["donald_j_trump_i_rep"] == 342
@@ -44,12 +44,12 @@ def test_georgia_precinct_formatting_vote_types_completion_mode(atkinson_precinc
     )
 
     # Pearson City precinct
-    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["pearson_city"]
+    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_pearson-city"]
     assert pearson["precinctsReportingPct"] == 100
     assert pearson["expectedVotes"] == 564
 
     # Willacoochee precinct
-    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
+    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_willacoochee"]
     assert willacoochee["precinctsReportingPct"] == 0
     assert willacoochee.get("expectedVotes") is None
 


### PR DESCRIPTION
## Description

I noticed three things about `elex-clarity` that seemed different than how `elex-state` handles precincts:

1. It groups precincts into county/race keys by adding the county ID to the end of `race_id`. So for a governor's race, for instance, there's one race per county with the precincts as subunits of each county/race pair, e.g. `2022-05-24_GA_R_G_13131` where `13131` is the county FIPS.
2. It doesn't add county ID to the precinct subunit ID.
3. It uses an underscore to slugify the precinct name, rather than a dash.

This draft PR does not address 1 and assumes this is expected behavior.

It does address 2 and 3 by adding the `county_id` to precinct IDs and uses a dash to slugify precinct names after that, so a precinct ID of `pearson_city` becomes `13003_pearson-city`.

## Test Steps
```sh
elexclarity 113667 GA --level=precinct --countyMapping="$(cat tests/fixtures/mappings/GA_county_fips.json)"
```
