### PR TITLE
fix: remove extraneous slash from Clarity base URL

### DIFF
--- a/src/elexclarity/cli.py
+++ b/src/elexclarity/cli.py
@@ -15,7 +15,7 @@ class StringListParamType(click.ParamType):
         return value.split(",")
 
 
-BASE_URL = os.environ.get('CLARITY_API_BASE_URL', 'https://results.enr.clarityelections.com/')
+BASE_URL = os.environ.get('CLARITY_API_BASE_URL', 'https://results.enr.clarityelections.com')
 STRING_LIST = StringListParamType()
 
 


### PR DESCRIPTION
## Description

Removes a trailing slash from the default Clarity base URL, which causes our requests to contain two slashes (because the client adds a slash):
```
https://results.enr.clarityelections.com//IA/115641/current_ver.txt
```

That doesn't seem to break anything, but I'd rather our URLs be precise.

## Test Steps

Ran the following:

```sh
elexclarity 115641 IA --level=precinct
```

I had to add some office mappings in `src/elexclarity/formatters/const.py` like these to get the command to complete:

```python
    "IA": {
        "United States Senator": "S",
        "United States Representative": "H",
        "Governor": "G",
        "Secretary of State": "R"
    }
```

(That's going in [this separate PR](#26).)

But once I did it worked.
