### PR TITLE
feat(ia): add office IDs to map WIP

### DIFF
--- a/src/elexclarity/formatters/const.py
+++ b/src/elexclarity/formatters/const.py
@@ -33,6 +33,12 @@ STATE_OFFICE_ID_MAPS = {
         'U.S. SENATOR': 'S'
     },
     "CA": {
+    },
+    "IA": {
+        "United States Senator": "S",
+        "United States Representative": "H",
+        "Governor": "G",
+        "Secretary of State": "R"
     }
 }
 


### PR DESCRIPTION
## Description

This draft PR adds some IA office mappings so the scraper completes. Needs more office mappings and/or to better deal with House districts.

## Test Steps

```sh
elexclarity 115641 IA --level=precinct
```

