### PR TITLE
feat: fake the user agent

### DIFF
--- a/src/elexclarity/client.py
+++ b/src/elexclarity/client.py
@@ -21,11 +21,13 @@ class ElectionsClient(object):
             timeout=5,
             session=None,
             retry_params={},
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
             **kwargs):
 
         if session is None:
             session = requests.Session()
             session.headers.update({'Accept-Encoding': 'gzip'})
+            session.headers.update({"User-Agent": user_agent})
 
         retry_params = {"total": 3, "status_forcelist": (502, 504, 429, 499), "backoff_factor": 0.2, **retry_params}
         adapter = HTTPAdapter(max_retries=Retry(**retry_params))

--- a/src/elexclarity/client.py
+++ b/src/elexclarity/client.py
@@ -21,7 +21,8 @@ class ElectionsClient(object):
             timeout=5,
             session=None,
             retry_params={},
-            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+            # faking a user-agent because Clarity is giving us forbidden errors otherwise
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36",
             **kwargs):
 
         if session is None:


### PR DESCRIPTION
## Description

Clarity results sites are returning `403 Client Error: Forbidden` when we send Python's default user agent or a custom WaPo user agent. This is likely a result of applying a blanket Web Application Firewall rule meant to generally block bots as part of an application security push. CDN/WAF providers have these sorts of rules as options. This fakes the user agent to appear as though the user is using a Safari web browser. That lets us through.

## Test Steps

```sh
tox
elexclarity 113667 GA --officeID=S --level=precinct
```
