### PR TITLE
feat: partially match office IDs for AR, GA, IA

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -24,10 +24,10 @@ class ClarityConverter(object):
     def get_race_office(self, contest_name):
         office_id_maps = STATE_OFFICE_ID_MAPS[self.state_postal]
 
-        contest_slug = slugify(contest_name, separator="_")
+        contest_slug = slugify(contest_name, separator="_", replacements=[['.','']])
 
         for name, id in office_id_maps.items():
-            slug = slugify(name, separator="_")
+            slug = slugify(name, separator="_", replacements=[['.','']])
             if slug in contest_slug:
                 return id
 

--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -22,7 +22,16 @@ class ClarityConverter(object):
         raise Exception(f"Unknown election type: {election_name}")
 
     def get_race_office(self, contest_name):
-        return STATE_OFFICE_ID_MAPS[self.state_postal].get(contest_name, slugify(contest_name, separator="_"))
+        office_id_maps = STATE_OFFICE_ID_MAPS[self.state_postal]
+
+        contest_slug = slugify(contest_name, separator="_")
+
+        for name, id in office_id_maps.items():
+            slug = slugify(name, separator="_")
+            if slug in contest_slug:
+                return id
+
+        return contest_slug
 
     @classmethod
     def get_choice_id(cls, name):

--- a/src/elexclarity/formatters/const.py
+++ b/src/elexclarity/formatters/const.py
@@ -1,38 +1,55 @@
+# mapping a partial contest names to IDs
+# these get slugified and partially matched in order
+# against slugified contest names
 STATE_OFFICE_ID_MAPS = {
     "GA": {
-        # Name cleanup for the 2020 Presidential election
+        'US President': 'P',
         'President of the United States': 'P',
-        'President of the United States/Presidentede los Estados Unidos': 'P',
-        'US Senate (Loeffler) - Special Election': 'S2',
         'US Senate (Loeffler) - Special': 'S2',
-        'US Senate (Loeffler) - Special/Senado de los EE.UU. (Loeffler) - Especial': 'S2',
-        'US Senate (Perdue)': 'S',
-        'US Senate (Perdue)/Senado de los EE.UU. (Perdue)': 'S',
-        # 2022 primaries
-        'US Senate - Rep': 'S',
-        'REP - US Senate': 'S',
-        'DEM - US Senate': 'S',
-        'US Senate - Dem': 'S',
-        'Governor - Rep': 'G',
-        'REP - Governor': 'G',
-        'DEM - Governor': 'G',
-        'Governor - Dem': 'G',
-        'Secretary of State - Rep': 'R',
-        'REP - Secretary of State': 'R',
-        'DEM - Secretary of State': 'R',
-        'Secretary of State - Dem': 'R',
-        "US Senate/ Senado de los EE.UU. - Rep": 'S',
-        'US Senate/ Senado de los EE.UU. - Dem': 'S',
-        'Governor/Gobernador - Rep': 'G',
-        'Governor/Gobernador - Dem': 'G',
-        'Secretary of State/ Secretario de Estado - Rep': 'R',
-        'Secretary of State/ Secretario de Estado - Dem': 'R'
+        'US Senat': 'S', # covers both US Senate and U.S. Senator
+        "United States Senat": "S",  # covers both US Senate and U.S. Senator
+        "United States House": "H",
+        'US Congress': 'H',
+        'US House': 'H',
+        'United States Congress': 'H',
+        "United States Rep": "H",
+        'US Rep': 'H',
+        'Governor': 'G',
+        'Secretary of State': 'R'
     },
     "WV": {
         'PRESIDENT': 'P',
         'U.S. SENATOR': 'S'
     },
     "CA": {
+    },
+    "IA": {
+        'US President': 'P',
+        'President of the United States': 'P',
+        'US Senat': 'S', # covers both US Senate and U.S. Senator
+        "United States Senat": "S",  # covers both US Senate and U.S. Senator
+        "United States House": "H",
+        'US Congress': 'H',
+        'US House': 'H',
+        'United States Congress': 'H',
+        "United States Rep": "H",
+        'US Rep': 'H',
+        'Governor': 'G',
+        'Secretary of State': 'R'
+    },
+    "AR": {
+        'US President': 'P',
+        'President of the United States': 'P',
+        'US Senat': 'S', # covers both US Senate and U.S. Senator
+        "United States Senat": "S",  # covers both US Senate and U.S. Senator
+        "United States House": "H",
+        'US Congress': 'H',
+        'US House': 'H',
+        'United States Congress': 'H',
+        "United States Rep": "H",
+        'US Rep': 'H',
+        'Governor': 'G',
+        'Secretary of State': 'R'
     }
 }
 


### PR DESCRIPTION
## Description

This PR partially matches office IDs in three states, so even if one county decides to call their Senate contest "US Senate/ Senado de los EE.UU. - Rep," we still match it. This includes a relatively broad list of potential names for each state, but each is unlikely to match incorrect contest names, given "U.S. Rep" is unlikely to be anything other than a contest for a United States House Representative. In effect, this adds Iowa and Arkansas to Clarity and is the first step towards adding U.S. House support for Georgia (the second step is parsing out the House district, see #29).

## Test Steps

```sh
tox
elexclarity 106126 AR --level=precinct --countyName=Arkansas
elexclarity 113669 GA --level=precinct --countyName=Appling
elexclarity 115642 IA --level=precinct --countyName=Adair
```