### PR TITLE
feat: add district number to U.S. house office ID

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -1,3 +1,4 @@
+import re
 from slugify import slugify
 from dateutil import parser, tz
 
@@ -26,12 +27,20 @@ class ClarityConverter(object):
 
         contest_slug = slugify(contest_name, separator="_", replacements=[['.','']])
 
+        office_id = contest_slug
+
         for name, id in office_id_maps.items():
             slug = slugify(name, separator="_", replacements=[['.','']])
             if slug in contest_slug:
-                return id
+                office_id = id
+                break # stop at first match
 
-        return contest_slug
+        if office_id == "H" and "district" in contest_slug:
+            district_match = re.search(r"district_([0-9]+)", contest_slug)
+            if district_match:
+                office_id += f"_{int(district_match.group(1))}"
+
+        return office_id
 
     @classmethod
     def get_choice_id(cls, name):

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -260,7 +260,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
             )
 
             race_office = race_result.get('office')
-            if not office_id or race_office in office_id:
+            if not office_id or race_office[0] in office_id:
                 result[race_result["id"]] = race_result
 
         return result

--- a/tests/formatters/test_results.py
+++ b/tests/formatters/test_results.py
@@ -1,4 +1,5 @@
 from elexclarity.formatters.results import ClarityDetailXMLConverter
+from elexclarity.formatters.base import ClarityConverter
 
 
 def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping_fips):
@@ -131,3 +132,14 @@ def test_county_formatting_no_county_mapping(wv_counties):
     assert marshall_county["counts"]["joseph_r_biden"] == 3455
     assert marshall_county["counts"]["jo_jorgensen"] == 143
     assert marshall_county["counts"]["howie_hawkins"] == 47
+
+def test_georgia_get_race_office():
+    converter = ClarityConverter(statepostal="GA")
+
+    assert converter.get_race_office("U.S. House Representative") == "H"
+    assert converter.get_race_office("U.S. House Representative District 01") == "H_1"
+    assert converter.get_race_office("U.S. House Representative District 10") == "H_10"
+    assert converter.get_race_office("US Senate") == "S"
+    assert converter.get_race_office("United States Senator") == "S"
+    assert converter.get_race_office("U.S. Senate Loeffler Special") == "S2"
+    assert converter.get_race_office("US President and Vice President") == "P"


### PR DESCRIPTION
## Description

This PR builds on #28 to add district numbers to IDs for U.S. House races to elex-clarity. For instance, `2022-11-08_IA_G_H_3` for the U.S. House race in the 3rd district of the Iowa general election. It also adds a test.

## Test Steps

```sh
tox
elexclarity 115641 IA --officeID=H
```