### PR TITLE
fix: fall back when looking up county

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -57,7 +57,9 @@ class ClarityConverter(object):
         slug = slugify(name, separator="_")
         if not self.county_lookup:  # No mapping provided
             return slug
-        return self.county_lookup.get(name, self.county_lookup.get(name.replace('_',' '), slug))
+        return self.county_lookup.get(
+            name, self.county_lookup.get(name.replace("_", " "), slug)
+        )
 
     @classmethod
     def get_timestamp(cls, input_timestamp):

--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -57,7 +57,7 @@ class ClarityConverter(object):
         slug = slugify(name, separator="_")
         if not self.county_lookup:  # No mapping provided
             return slug
-        return self.county_lookup[name]
+        return self.county_lookup.get(name, self.county_lookup.get(name.replace('_',' '), slug))
 
     @classmethod
     def get_timestamp(cls, input_timestamp):

--- a/tests/formatters/test_base.py
+++ b/tests/formatters/test_base.py
@@ -1,0 +1,8 @@
+from elexclarity.formatters.base import ClarityConverter
+
+def test_get_county_id():
+    converter = ClarityConverter("AR", county_lookup={"Hot Spring": "1234"})
+
+    assert converter.get_county_id("Hot Spring") == "1234"
+    assert converter.get_county_id("Hot_Spring") == "1234"
+    assert converter.get_county_id("Not a County") == "not_a_county"

--- a/tests/formatters/test_base.py
+++ b/tests/formatters/test_base.py
@@ -1,8 +1,18 @@
 from elexclarity.formatters.base import ClarityConverter
 
-def test_get_county_id():
+
+def test_arkansas_get_county_id():
     converter = ClarityConverter("AR", county_lookup={"Hot Spring": "1234"})
 
     assert converter.get_county_id("Hot Spring") == "1234"
     assert converter.get_county_id("Hot_Spring") == "1234"
     assert converter.get_county_id("Not a County") == "not_a_county"
+
+
+def test_georgia_get_county_id():
+    converter = ClarityConverter(
+        "GA", county_lookup={"Ben Hill": "1234", "Jeff Davis": "3456"}
+    )
+
+    assert converter.get_county_id("Ben_Hill") == "1234"
+    assert converter.get_county_id("Jeff_Davis") == "3456"


### PR DESCRIPTION
## Description

This bulletproofs the county mapping lookup, which was erroring on a county with the value "Hot_Spring" in the Arkansas test election. It also reduces the need for [some of the hacks](https://github.com/WPMedia/elex-data-importer/blob/080f2a13d489516f0fbc9cce4bf7b13936c39a79/elexdata/events/imports/clarity.py#L57-L61) that have been made to work around this issue for Georgia in data importer.

## Test Steps

```sh
elexclarity 115767 AR --officeID=S,H,G --level=precinct --countyMapping='{"Hot_Spring":"5754"}'
tox
```
