### PR TITLE
fix: correctly handle non-EST timezones

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -4,6 +4,16 @@ from dateutil import parser, tz
 
 from elexclarity.formatters.const import STATE_OFFICE_ID_MAPS, STATE_RACE_TYPE_MAPS
 
+US_TIMEZONES = {
+    "PST": tz.gettz("US/Pacific"),
+    "PDT": tz.gettz("US/Pacific"),
+    "MST": tz.gettz("US/Mountain"),
+    "MDT": tz.gettz("US/Mountain"),
+    "CST": tz.gettz("US/Central"),
+    "CDT": tz.gettz("US/Central"),
+    "EST": tz.gettz("US/Eastern"),
+    "EDT": tz.gettz("US/Eastern"),
+}
 
 class ClarityConverter(object):
     def __init__(self, statepostal, county_lookup=None, **kwargs):
@@ -63,9 +73,8 @@ class ClarityConverter(object):
 
     @classmethod
     def get_timestamp(cls, input_timestamp):
-        # convert the timestamp and make sure we're in EST
-        est = tz.gettz("America/New_York")
-        return parser.parse(input_timestamp, tzinfos={"EST": est}).astimezone(tz.gettz("UTC"))
+        # convert the timestamp
+        return parser.parse(input_timestamp, tzinfos=US_TIMEZONES).astimezone(tz.gettz("UTC"))
 
     @classmethod
     def format_last_updated(cls, input_timestamp):

--- a/tests/formatters/test_base.py
+++ b/tests/formatters/test_base.py
@@ -1,4 +1,6 @@
 from elexclarity.formatters.base import ClarityConverter
+from datetime import datetime
+from dateutil import tz
 
 
 def test_arkansas_get_county_id():
@@ -16,3 +18,9 @@ def test_georgia_get_county_id():
 
     assert converter.get_county_id("Ben_Hill") == "1234"
     assert converter.get_county_id("Jeff_Davis") == "3456"
+
+
+def test_get_timestamp():
+    converter = ClarityConverter("IA")
+
+    assert converter.get_timestamp("10/17/2022 2:21:22 PM CDT") == datetime(2022, 10, 17, 19, 21, 22, tzinfo=tz.gettz("UTC"))


### PR DESCRIPTION
## Description

This PR addresses an error message that the CDT timezone isn't recognized encountered when parsing Iowa and Arkansas by adding support for several common U.S. timezone abbreviations, including CDT, PST, etc.

## Test Steps

```sh
tox
```