### PR TITLE
chore: properly end literal string in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ Retrieving raw data:
 * ``elexclarity 105369 GA --outputType=summary --style=raw``
 * ``elexclarity 105369 GA --outputType=settings --style=raw``
 * ``elexclarity 105369 GA --level=precinct --style=raw``
-* ``elexclarity 106043 CA --countyName Santa_Clara --level=precinct
+* ``elexclarity 106043 CA --countyName Santa_Clara --level=precinct``
 
 Retrieving + formatting settings (for presidential races):
 


### PR DESCRIPTION
## Description

Seeing the following when we try to deploy:
```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         The description failed to render in the default format of              
         reStructuredText. See https://pypi.org/help/#description-content-type  
         for more information.      
```

Ran `rst-lint` on README.rst, which is pulled into setup.py as an extended description and got:
```
WARNING README.rst:140 Inline literal start-string without end-string.
```

This PR adds an end-string to the literal.

## Test Steps

```sh
pip install restructuredtext_lint
rst-lint README.rst
```
