### PR TITLE
fix: remove county ID from precinct ID

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -57,7 +57,7 @@ class ClarityConverter(object):
         return slugify(name, separator="_")
 
     def get_precinct_id(self, name, county_id=None):
-        return "_".join(filter(None,[county_id, slugify(name, separator='-')]))
+        return slugify(name, separator="-")
 
     def get_county_id(self, name):
         """

--- a/tests/formatters/test_results.py
+++ b/tests/formatters/test_results.py
@@ -20,7 +20,7 @@ def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping
     assert counts["jo_jorgensen_lib"] == 30
 
     # Pearson City precinct
-    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_pearson-city"]
+    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["pearson-city"]
     assert pearson["precinctsReportingPct"] == 100
     assert pearson["expectedVotes"] == 564
     assert pearson["counts"]["donald_j_trump_i_rep"] == 229
@@ -28,7 +28,7 @@ def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping
     assert pearson["counts"]["jo_jorgensen_lib"] == 6
 
     # Willacoochee precinct
-    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_willacoochee"]
+    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
     assert willacoochee["precinctsReportingPct"] == 100
     assert willacoochee["expectedVotes"] == 522
     assert willacoochee["counts"]["donald_j_trump_i_rep"] == 342
@@ -45,12 +45,12 @@ def test_georgia_precinct_formatting_vote_types_completion_mode(atkinson_precinc
     )
 
     # Pearson City precinct
-    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_pearson-city"]
+    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["pearson-city"]
     assert pearson["precinctsReportingPct"] == 100
     assert pearson["expectedVotes"] == 564
 
     # Willacoochee precinct
-    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_willacoochee"]
+    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
     assert willacoochee["precinctsReportingPct"] == 0
     assert willacoochee.get("expectedVotes") is None
 


### PR DESCRIPTION
## Description

This reverses part of #20 to remove the county ID from the precinct identifier, so that the importer Clarity state machine doesn't add it a second time, like `2022-11-08_IA_G_S_19181_19181_virginia`. The precinct ID will therefore just `virginia` in that case, and the race ID will be `2022-11-08_IA_G_S_19181`, together they will be `2022-11-08_IA_G_S_19181_virginia`.

## Test Steps

```sh
tox
```
