### PR TITLE
fix: remove locality from race ID, add it back to subunit ID

### DIFF
--- a/src/elexclarity/convert.py
+++ b/src/elexclarity/convert.py
@@ -53,6 +53,9 @@ def convert(
                 data,
                 vote_completion_mode=vote_completion_mode,
                 office_id=office_id,
+                omit_locality_from_race_id=kwargs.get(
+                    "omit_locality_from_race_id", True
+                ),
                 **kwargs
             )
 

--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -57,7 +57,7 @@ class ClarityConverter(object):
         return slugify(name, separator="_")
 
     def get_precinct_id(self, name, county_id=None):
-        return slugify(name, separator="-")
+        return "_".join(filter(None,[county_id, slugify(name, separator='-')]))
 
     def get_county_id(self, name):
         """

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -200,7 +200,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
             election_type,
             office
         ]
-        if level == "precinct":
+        if level == "precinct" and not kwargs.get("omit_locality_from_race_id"):
             id_parts.append(county_id)
         race_id = "_".join(id_parts)
 

--- a/tests/formatters/test_results.py
+++ b/tests/formatters/test_results.py
@@ -20,7 +20,7 @@ def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping
     assert counts["jo_jorgensen_lib"] == 30
 
     # Pearson City precinct
-    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["pearson-city"]
+    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_pearson-city"]
     assert pearson["precinctsReportingPct"] == 100
     assert pearson["expectedVotes"] == 564
     assert pearson["counts"]["donald_j_trump_i_rep"] == 229
@@ -28,7 +28,7 @@ def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping
     assert pearson["counts"]["jo_jorgensen_lib"] == 6
 
     # Willacoochee precinct
-    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
+    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_willacoochee"]
     assert willacoochee["precinctsReportingPct"] == 100
     assert willacoochee["expectedVotes"] == 522
     assert willacoochee["counts"]["donald_j_trump_i_rep"] == 342
@@ -45,12 +45,12 @@ def test_georgia_precinct_formatting_vote_types_completion_mode(atkinson_precinc
     )
 
     # Pearson City precinct
-    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["pearson-city"]
+    pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_pearson-city"]
     assert pearson["precinctsReportingPct"] == 100
     assert pearson["expectedVotes"] == 564
 
     # Willacoochee precinct
-    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["willacoochee"]
+    willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_willacoochee"]
     assert willacoochee["precinctsReportingPct"] == 0
     assert willacoochee.get("expectedVotes") is None
 


### PR DESCRIPTION
## Description

This PR removes the county name or FIPS code from the race ID when you request a single county (as the Clarity state machine in importer does) and adds it back to the subunit ID, as required by the model. It continues to add the locality identifier to the race ID when you request multiple counties so counties don't clobber each other, this behavior can be configured by a hidden keyword argument.

## Test Steps

```sh
elexclarity 115843 AR --level=precinct --officeID=S --countyName Yell
```

## After

```js
{
  "2022-11-08_AR_G_S": {
    "id": "2022-11-08_AR_G_S",
    "source": "clarity",
    "precinctsReportingPct": 0.0,
    "counts": {
      "natalie_james": 0,
      "senator_john_boozman": 0,
      "kenneth_cates": 0
    },
    "office": "S",
    "lastUpdated": "2022-11-07T20:57:58Z",
    "subunits": {
      "yell_bluffton": {
        "id": "yell_bluffton",
    // snip
```

## Before

```js
{
  "2022-11-08_AR_G_S_yell": {
    "id": "2022-11-08_AR_G_S_yell",
    "source": "clarity",
    "precinctsReportingPct": 0.0,
    "counts": {
      "natalie_james": 0,
      "senator_john_boozman": 0,
      "kenneth_cates": 0
    },
    "office": "S",
    "lastUpdated": "2022-11-07T20:57:58Z",
    "subunits": {
      "bluffton": {
        "id": "bluffton",
    // snip
```