### PR TITLE
feat: add candidate mapping

### DIFF
--- a/src/elexclarity/cli.py
+++ b/src/elexclarity/cli.py
@@ -25,6 +25,7 @@ STRING_LIST = StringListParamType()
 @click.option('--countyName', 'county_name', type=click.STRING, help="If county specific clarity page")
 @click.option('--filename', type=click.Path(exists=True), help='Specify data file instead of making HTTP request')
 @click.option('--countyMapping', 'countyMapping', default={}, help='Specify county mapping')
+@click.option('--candidateMapping', 'candidateMapping', default={}, help='Specify candidate mapping')
 @click.option('--officeID', 'officeID', help='The office ID(s) to process', type=STRING_LIST)
 @click.option('--level', help='Specify the subunit type/reporting level for results', default='county', type=click.Choice([
     'county',
@@ -44,7 +45,7 @@ STRING_LIST = StringListParamType()
     'default',
     'raw'
 ]))
-def cli(electionid, statepostal, filename=None, countyMapping={}, outputType="results", **kwargs):
+def cli(electionid, statepostal, filename=None, countyMapping={}, candidateMapping={}, outputType="results", **kwargs):
     """
     This tool accepts an election ID (e.g. 105369) and a state postal code (e.g. GA)
     and the options below and outputs formatted elections data. If a filename is provided,
@@ -77,7 +78,10 @@ def cli(electionid, statepostal, filename=None, countyMapping={}, outputType="re
     if isinstance(countyMapping, str):
         countyMapping = json.loads(countyMapping)
 
-    result = convert(result, statepostal, outputType=outputType, countyMapping=countyMapping, **kwargs)
+    if isinstance(candidateMapping, str):
+        candidateMapping = json.loads(candidateMapping)
+
+    result = convert(result, statepostal, outputType=outputType, countyMapping=countyMapping, candidateMapping=candidateMapping, **kwargs)
     LOG.debug("Total length: ", len(result))
 
     print(json.dumps(result, indent=2))

--- a/src/elexclarity/convert.py
+++ b/src/elexclarity/convert.py
@@ -8,6 +8,7 @@ def convert(
     outputType="results",
     style="default",
     countyMapping=None,
+    candidateMapping=None,
     officeID=None,
     voteCompletionMode=None,
     **kwargs
@@ -26,7 +27,7 @@ def convert(
         return data
 
     if outputType == "settings":
-        return ClaritySettingsConverter(statepostal, county_lookup=countyMapping).convert(
+        return ClaritySettingsConverter(statepostal, county_lookup=countyMapping, candidate_lookup=candidateMapping).convert(
             data,
             office_id=office_id,
             **kwargs
@@ -35,7 +36,8 @@ def convert(
     if outputType == "results":
         converter = ClarityDetailXMLConverter(
             statepostal,
-            county_lookup=countyMapping
+            county_lookup=countyMapping,
+            candidate_lookup=candidateMapping
         )
 
         if isinstance(data, list):

--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -16,9 +16,10 @@ US_TIMEZONES = {
 }
 
 class ClarityConverter(object):
-    def __init__(self, statepostal, county_lookup=None, **kwargs):
+    def __init__(self, statepostal, county_lookup=None, candidate_lookup=None, **kwargs):
         self.state_postal = statepostal
         self.county_lookup = county_lookup
+        self.candidate_lookup = candidate_lookup
 
     def get_race_type(self, election_name, *, contest={}):
         contest_name = contest.get('text', '')

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -106,6 +106,8 @@ class ClarityDetailXMLConverter(ClarityConverter):
             for subunit_id, subunit_choice_votes in choice_votes_by_subunit.items():
                 subunit_results.setdefault(subunit_id, {"id": subunit_id, "counts": defaultdict(lambda: 0)})
                 choice_id = self.get_choice_id(choice.get("text"))
+                if self.candidate_lookup:
+                    choice_id = self.candidate_lookup.get(choice_id, choice_id)
                 subunit_results[subunit_id]["counts"][choice_id] += subunit_choice_votes
 
         if subunit_fully_reporting_statuses:
@@ -125,6 +127,8 @@ class ClarityDetailXMLConverter(ClarityConverter):
 
         for choice in choices:
             choice_id = self.get_choice_id(choice.get("text"))
+            if self.candidate_lookup:
+                choice_id = self.candidate_lookup.get(choice_id, choice_id)
             counts[choice_id] = int(choice["totalVotes"])
 
         return counts


### PR DESCRIPTION
## Description

This PR adds a feature to elex-clarity to map candidate IDs using a mapping fed from the CLI or the API.

## Test Steps

```sh
elexclarity 115470 GA --level=precinct --officeID=S --countyName=Baker --candidateMapping='{"herschel_junior_walker_rep":"herschel_junior_walker_gop"}' > out.json
```
