### PR TITLE
feat: add count by vote type to subunits

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -2,7 +2,11 @@ import re
 from slugify import slugify
 from dateutil import parser, tz
 
-from elexclarity.formatters.const import STATE_OFFICE_ID_MAPS, STATE_RACE_TYPE_MAPS
+from elexclarity.formatters.const import (
+    STATE_OFFICE_ID_MAPS,
+    STATE_RACE_TYPE_MAPS,
+    STATE_VOTE_TYPE_MAPS,
+)
 
 US_TIMEZONES = {
     "PST": tz.gettz("US/Pacific"),
@@ -65,6 +69,11 @@ class ClarityConverter(object):
 
     def get_precinct_id(self, name, county_id=None):
         return "_".join(filter(None,[county_id, slugify(name, separator='-')]))
+
+    def get_vote_type_id(self, name):
+        id = slugify(name, separator='-').replace("-votes", "")
+        id = STATE_VOTE_TYPE_MAPS.get(self.state_postal,{}).get(id, id)
+        return id
 
     def get_county_id(self, name):
         """

--- a/src/elexclarity/formatters/const.py
+++ b/src/elexclarity/formatters/const.py
@@ -76,3 +76,10 @@ STATE_RACE_TYPE_MAPS = {
         'Secretary of State/ Secretario de Estado - Dem': 'D'
     }
 }
+
+STATE_VOTE_TYPE_MAPS = {
+    "AR": {
+        "early-vote-north": "early-vote",
+        "early-vote-south": "early-vote"
+    }
+}

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -16,6 +16,16 @@ def test_precinct_level_results(bacon_precincts, ga_county_mapping_fips):
 
     assert len(results) == 20
     assert "2020-11-03_GA_G_P_13005" in results
+    assert "13005_douglas" in results["2020-11-03_GA_G_P_13005"]["subunits"]
+
+
+def test_precinct_level_results_vote_types(bacon_precincts, ga_county_mapping_fips):
+    results = convert([bacon_precincts], statepostal="GA", level="precinct", countyMapping=ga_county_mapping_fips)
+
+    assert "voteTypes" in results["2020-11-03_GA_G_P_13005"]["subunits"]["13005_douglas"]
+    assert "election-day" in results["2020-11-03_GA_G_P_13005"]["subunits"]["13005_douglas"]["voteTypes"]
+    assert "2020-11-03_GA_G_P_13005_joseph_r_biden_dem" in results["2020-11-03_GA_G_P_13005"]["subunits"]["13005_douglas"]["voteTypes"]["election-day"]
+    assert results["2020-11-03_GA_G_P_13005"]["subunits"]["13005_douglas"]["voteTypes"]["election-day"]["2020-11-03_GA_G_P_13005_joseph_r_biden_dem"] == 140
 
 
 def test_county_level_results(ga_counties, ga_county_mapping_fips):


### PR DESCRIPTION
## Description

This PR adds votes broken down by type to each subunit. It reports those in a `voteTypes` key, slugifying each vote type and allowing multiple vote types to be mapped into a single standard vote type defined per state (in Arkansas we use this to map `early-vote-north` and `early-vote-south`, observed in at least one case, to `early-vote`).

The result looks like this:

```json
      "baker_milford": {
        "id": "baker_milford",
        "counts": {
          "2022-11-08_GA_G_S_herschel_junior_walker_rep": 198,
          "2022-11-08_GA_G_S_raphael_warnock_i_dem": 76,
          "2022-11-08_GA_G_S_chase_oliver_l": 3
        },
        "voteTypes": {
          "absentee-by-mail": {
            "2022-11-08_GA_G_S_herschel_junior_walker_rep": 12,
            "2022-11-08_GA_G_S_raphael_warnock_i_dem": 18,
            "2022-11-08_GA_G_S_chase_oliver_l": 0
          },
          "advance-voting": {
            "2022-11-08_GA_G_S_herschel_junior_walker_rep": 83,
            "2022-11-08_GA_G_S_raphael_warnock_i_dem": 32,
            "2022-11-08_GA_G_S_chase_oliver_l": 0
          },
          "election-day": {
            "2022-11-08_GA_G_S_herschel_junior_walker_rep": 103,
            "2022-11-08_GA_G_S_raphael_warnock_i_dem": 26,
            "2022-11-08_GA_G_S_chase_oliver_l": 3
          },
          "provisional": {
            "2022-11-08_GA_G_S_herschel_junior_walker_rep": 0,
            "2022-11-08_GA_G_S_raphael_warnock_i_dem": 0,
            "2022-11-08_GA_G_S_chase_oliver_l": 0
          }
        },
```

## Jira Ticket

[ELEX-1947](https://arcpublishing.atlassian.net/browse/ELEX-1947)

## Test Steps

```sh
tox
elexclarity 115470 GA --level=precinct --officeID=S --countyName=Baker
```
