### PR TITLE
feat: add combined vote completion method

### DIFF
--- a/src/elexclarity/cli.py
+++ b/src/elexclarity/cli.py
@@ -39,7 +39,8 @@ STRING_LIST = StringListParamType()
 ]))
 @click.option('--voteCompletionMode', 'voteCompletionMode', default='percentReporting', type=click.Choice([
     'percentReporting',
-    'voteTypes'
+    'voteTypes',
+    'combined'
 ]))
 @click.option('--style', default='default', type=click.Choice([
     'default',

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -246,7 +246,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
             # fields at the ElectionResult level in the precinct detail XML files
             subunit_fully_reporting_statuses = self._get_precinct_fully_reporting_statuses_via_percent_reporting(dictified_data, county_id=county_id)
         else:
-            subunit_fully_reporting_statuses = None
+            subunit_fully_reporting_statuses = {}
 
         for contest in get_list(dictified_data.get("Contest")):
             election_type = self.get_race_type(dictified_data["ElectionName"], contest=contest)


### PR DESCRIPTION
## Description

This PR adds a `voteCompletionMethod` of `combined`, which looks at both `percentReporting` and `voteTypes`, marking a precinct reporting only if the reporting flag is set and none of the vote types except provisional is zero.

## Jira Ticket

TKTK

## Test Steps

Here's the very manual test I did:

1. I ran the following (and saw the percent reporting for Douglas is `100`):
```sh
elexclarity 115470 GA --level=precinct --officeID=P --countyName=Baker --voteCompletionMode=combined --filename=tests/fixtures/results/ga_bacon_precincts_11-3.xml
```
2. In `tests/fixtures/results/ga_bacon_precincts_11-3.xml` I modified `percentReporting` to be `3` instead of `4` and re-ran the above command. The precincts reporting for Douglas dropped to `0`, which is correct.
3. Then I reset that value to `4` and modified the election day votes for each of the three presidential candidates so `votes="0"` and re-ran. The precincts reporting for Douglas remained `0`, which is correct.

This should probably go in an automated test, I am considering forgoing right now for expediency, but dear reviewer, set me straight if you feel otherwise.
