### PR TITLE
feat: add election date override

### DIFF
--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -248,7 +248,7 @@ class ClarityDetailXMLConverter(ClarityConverter):
             county_id = self.get_county_id(region)
         else:
             county_id = None
-        election_date = self.format_date(dictified_data["ElectionDate"])
+        election_date = kwargs.get("date", self.format_date(dictified_data["ElectionDate"]))
         timestamp = self.format_last_updated(dictified_data["Timestamp"])
 
         if level == "precinct" and vote_completion_mode in ["percentReporting", "combined"]:

--- a/tests/formatters/test_results.py
+++ b/tests/formatters/test_results.py
@@ -35,6 +35,14 @@ def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping
     assert willacoochee["counts"]["2020-11-03_GA_G_P_13003_joseph_r_biden_dem"] == 174
     assert willacoochee["counts"]["2020-11-03_GA_G_P_13003_jo_jorgensen_lib"] == 6
 
+def test_formatting_date_override(atkinson_precincts, ga_county_mapping_fips):
+    results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(
+        atkinson_precincts,
+        level="precinct",
+        date="2022-12-06"
+    )
+
+    assert "2022-12-06_GA_G_P_13003" in results
 
 def test_georgia_precinct_formatting_vote_types_completion_mode(atkinson_precincts, ga_county_mapping_fips):
     results = ClarityDetailXMLConverter("GA", county_lookup=ga_county_mapping_fips).convert(


### PR DESCRIPTION
## Description

This PR adds a way to override the election date when formatting results by using the date supplied when invoking elex-clarity. There is no CLI argument for this, but the convert method does get the date from importer, and this lets us set that to whatever we want, allowing us to use one election to stand in for another when testing.

## Steps to Test

```sh
tox
```