### PR TITLE
feat: add reporting status flag for subunits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ Other parameters
      - N
      - percentReporting
    * - precinctsReportingPct
-     - a county-level override for the precincts reprting percent that applies to all subunits, given as a mapping between county IDs and percents
+     - a county-level override for the precincts reprting percent that applies to all subunits, given as a mapping between county IDs and percents (does not change the value of the reportingStatus field)
      - object
      - N
      - --

--- a/src/elexclarity/formatters/const.py
+++ b/src/elexclarity/formatters/const.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 # mapping a partial contest names to IDs
 # these get slugified and partially matched in order
 # against slugified contest names
@@ -83,3 +85,9 @@ STATE_VOTE_TYPE_MAPS = {
         "early-vote-south": "early-vote"
     }
 }
+
+class ReportingStatuses(str, Enum):
+    # Race not yet reporting
+    NOT_REPORTING = "NOT_REPORTING"
+    # Votes are reporting
+    REPORTING = "REPORTING"

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -4,6 +4,7 @@ import xmltodict
 from elexclarity.formatters.base import ClarityConverter
 from elexclarity.utils import get_list
 
+from elexclarity.formatters.const import ReportingStatuses
 
 class ClarityDetailXMLConverter(ClarityConverter):
     """
@@ -145,6 +146,11 @@ class ClarityDetailXMLConverter(ClarityConverter):
                     precincts_reporting_pct_override=precincts_reporting_pct_override,
                 )
                 subunit_result["precinctsReportingPct"] = precincts_reporting_pct
+                subunit_result["reportingStatus"] = (
+                    ReportingStatuses.REPORTING
+                    if subunit_fully_reporting_statuses.get(subunit_id)
+                    else ReportingStatuses.NOT_REPORTING
+                )
                 if precincts_reporting_pct == 100:
                     subunit_result["expectedVotes"] = sum(subunit_results[subunit_id]["counts"].values())
 

--- a/src/elexclarity/formatters/results.py
+++ b/src/elexclarity/formatters/results.py
@@ -146,6 +146,8 @@ class ClarityDetailXMLConverter(ClarityConverter):
                     precincts_reporting_pct_override=precincts_reporting_pct_override,
                 )
                 subunit_result["precinctsReportingPct"] = precincts_reporting_pct
+                # reportingStatus deliberately ignores precincts_reporting_pct override
+                # so we can monitor the status independent of the override
                 subunit_result["reportingStatus"] = (
                     ReportingStatuses.REPORTING
                     if subunit_fully_reporting_statuses.get(subunit_id)

--- a/tests/formatters/test_results.py
+++ b/tests/formatters/test_results.py
@@ -1,5 +1,6 @@
 from elexclarity.formatters.results import ClarityDetailXMLConverter
 from elexclarity.formatters.base import ClarityConverter
+from elexclarity.formatters.const import ReportingStatuses
 
 
 def test_georgia_precinct_formatting_basic(atkinson_precincts, ga_county_mapping_fips):
@@ -47,11 +48,13 @@ def test_georgia_precinct_formatting_vote_types_completion_mode(atkinson_precinc
     # Pearson City precinct
     pearson = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_pearson-city"]
     assert pearson["precinctsReportingPct"] == 100
+    assert pearson["reportingStatus"] == ReportingStatuses.REPORTING
     assert pearson["expectedVotes"] == 564
 
     # Willacoochee precinct
     willacoochee = results["2020-11-03_GA_G_P_13003"]["subunits"]["13003_willacoochee"]
     assert willacoochee["precinctsReportingPct"] == 0
+    assert willacoochee["reportingStatus"] == ReportingStatuses.NOT_REPORTING
     assert willacoochee.get("expectedVotes") is None
 
 


### PR DESCRIPTION
## Description

This PR adds a rudimentary reporting status categorical flag for subunits. Right now it is limited to two states: `REPORTING` and `NOT_REPORTING`. This is based on whatever `voteCompletionMode` is set, but critically it does not respect any reporting percent overrides added in #52 (this seems inconsistent, but we're doing this very deliberately to monitor the original reporting status even when overridden).

Ideally we'd like to expand this to more fully reflect elex-ap's range of values, including possibly `EARLY_VOTING_REPORTING`, `LIMITED_REPORTING`, `EST_FULLY_REPORTING` and `CERTIFIED`, but not today.

Note: This PR ladders on #52 and should be merged after it.

## Jira Ticket

[ELEX-1966](https://arcpublishing.atlassian.net/browse/ELEX-1966)

## Test Steps

```sh
elexclarity 115470 GA --level=precinct --officeID=P --countyName=Bacon --voteCompletionMode=combined --precinctsReportingPct='{"bacon":0}' --filename="tests/fixtures/results/ga_bacon_precincts_11-3.xml"
```

This should yield the following under the Douglas subunit:
```js
        "precinctsReportingPct": 0,
        "reportingStatus": "REPORTING"
```

This is the correct behavior.

If we hand edit that fixture so `percentReporting="3"` returns under `VoterTurnout` it will flip to:
```js
        "precinctsReportingPct": 0,
        "reportingStatus": "NOT_REPORTING"
```
