### PR TITLE
feat: clean GA precinct IDs

### DIFF
--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -68,9 +68,12 @@ class ClarityConverter(object):
         return choice_id
 
     def get_precinct_id(self, name, county_id=None):
+        precinct_id = "_".join(filter(None,[county_id, slugify(name, separator='-')]))
         if county_id.lower() == "gwinnett" or county_id == "13135":
-            name = re.sub(r'^[0-9]+ ', '', name)
-        return "_".join(filter(None,[county_id, slugify(name, separator='-')]))
+            precinct_id = re.sub(r'^[0-9]+-', '', precinct_id)
+        if county_id.lower() == "chatham" or county_id == "13051":
+            precinct_id = re.sub(r'(-savannah|-garden-city)$', '', precinct_id)
+        return precinct_id
 
     def get_vote_type_id(self, name):
         id = slugify(name, separator='-').replace("-votes", "")

--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -68,6 +68,8 @@ class ClarityConverter(object):
         return choice_id
 
     def get_precinct_id(self, name, county_id=None):
+        if county_id.lower() == "gwinnett" or county_id == "13135":
+            name = re.sub(r'^[0-9]+ ', '', name)
         return "_".join(filter(None,[county_id, slugify(name, separator='-')]))
 
     def get_vote_type_id(self, name):

--- a/src/elexclarity/formatters/base.py
+++ b/src/elexclarity/formatters/base.py
@@ -68,12 +68,25 @@ class ClarityConverter(object):
         return choice_id
 
     def get_precinct_id(self, name, county_id=None):
-        precinct_id = "_".join(filter(None,[county_id, slugify(name, separator='-')]))
+        slug = slugify(name, separator="-")
         if county_id.lower() == "gwinnett" or county_id == "13135":
-            precinct_id = re.sub(r'^[0-9]+-', '', precinct_id)
+            slug = re.sub(r"^[0-9]+-", "", slug)
         if county_id.lower() == "chatham" or county_id == "13051":
-            precinct_id = re.sub(r'(-savannah|-garden-city)$', '', precinct_id)
-        return precinct_id
+            if slug in [
+                "3-14c-oglethorpe-charter-academy",
+                "5-06c-seed-church",
+                "6-10c-georgetown-elementary",
+                "6-11c-coastal-ga-botanical-gardens",
+                "7-08c-bloomingdale-comm-ctr",
+                "7-09c-compassion-christian-henderson",
+            ]:
+                slug = f"{slug}-savannah"
+            if slug in [
+                "7-13c-southside-fire-trng-ctr",
+                "8-03c-silk-hope-baptist-church",
+            ]:
+                slug = f"{slug}-garden-city"
+        return "_".join(filter(None, [county_id, slug]))
 
     def get_vote_type_id(self, name):
         id = slugify(name, separator='-').replace("-votes", "")


### PR DESCRIPTION
## Description

This PR removes leading numbers from Gwinnett precinct identifiers to improve consistency between our data and precinct identifiers in the runoff results. It also adds some suffixes from Chatham county precinct IDs.

## Test Steps

```sh
elexclarity 116632 GA --countyName=Gwinnett --level=precinct --countyMapping='{"Gwinnett":"13135"}'
elexclarity 116590 GA --countyName=Chatham --level=precinct
```

## After

```json
      "13135_baycreek-c": {
        "id": "13135_baycreek-c",
```

## Before

```json
      "gwinnett_156-baycreek-j": {
        "id": "13135_156-baycreek-j",
```



